### PR TITLE
Support TGroup action in delta logs

### DIFF
--- a/crates/core/src/kernel/models/actions.rs
+++ b/crates/core/src/kernel/models/actions.rs
@@ -986,6 +986,45 @@ pub struct CheckpointMetadata {
     pub tags: Option<HashMap<String, Option<String>>>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+/// Defines a t-group action
+pub struct TGroup {
+    /// The T-Group URI for the table
+    pub tgroup_uri: String,
+
+    /// Time this log was added, as milliseconds since the Unix epoch.
+    pub timestamp: i64,
+
+    /// State of T-Group memebrship
+    pub redirect_state: RedirectState,
+}
+
+impl TGroup {
+    pub fn new(tgroup_uri: &str, redirect_state: RedirectState) -> Self {
+        Self {
+            tgroup_uri: String::from(tgroup_uri),
+            timestamp: chrono::Utc::now().timestamp_millis(),
+            redirect_state,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+/// The state of redirection for a table in a t-group
+pub enum RedirectState {
+    /// The table is in the process of being added to a t-group and is in a read-only state.
+    /// Writes must block or retry.
+    ReadOnly,
+
+    /// The table is part of a t-group. All reads and wries must redirect to the t-group's logs.
+    Redirect,
+
+    /// The table's addition to a t-group timed out. Reads and writes can proceed from the table's
+    /// logs and t-group addition must be retried.
+    TimedOut,
+}
+
 /// The sidecar action references a sidecar file which provides some of the checkpoint's file actions.
 /// This action is only allowed in checkpoints following V2 spec.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/core/src/kernel/models/fields.rs
+++ b/crates/core/src/kernel/models/fields.rs
@@ -19,6 +19,7 @@ impl ActionType {
             Self::DomainMetadata => &DOMAIN_METADATA_FIELD,
             Self::CheckpointMetadata => &CHECKPOINT_METADATA_FIELD,
             Self::Sidecar => &SIDECAR_FIELD,
+            Self::TGroup => &TGROUP_FIELD,
         }
     }
 }
@@ -207,6 +208,17 @@ static CHECKPOINT_METADATA_FIELD: LazyLock<StructField> = LazyLock::new(|| {
         StructType::new(vec![
             StructField::new("flavor", DataType::STRING, false),
             tags_field(),
+        ]),
+        true,
+    )
+});
+static TGROUP_FIELD: LazyLock<StructField> = LazyLock::new(|| {
+    StructField::new(
+        "tgroup",
+        StructType::new(vec![
+            StructField::new("tgroup_uri", DataType::STRING, false),
+            StructField::new("timestamp", DataType::LONG, false),
+            StructField::new("redirectState", DataType::STRING, false),
         ]),
         true,
     )

--- a/crates/core/src/kernel/models/mod.rs
+++ b/crates/core/src/kernel/models/mod.rs
@@ -35,6 +35,8 @@ pub enum ActionType {
     Txn,
     /// Checkpoint metadata
     CheckpointMetadata,
+    /// TGroup redirection,
+    TGroup,
     /// Sidecar
     Sidecar,
 }
@@ -52,6 +54,7 @@ pub enum Action {
     Txn(Transaction),
     CommitInfo(CommitInfo),
     DomainMetadata(DomainMetadata),
+    TGroup(TGroup),
 }
 
 impl Action {
@@ -112,6 +115,12 @@ impl From<DomainMetadata> for Action {
     }
 }
 
+impl From<TGroup> for Action {
+    fn from(a: TGroup) -> Self {
+        Self::TGroup(a)
+    }
+}
+
 impl Action {
     /// Get the action type
     pub fn action_type(&self) -> ActionType {
@@ -124,6 +133,7 @@ impl Action {
             Self::Txn(_) => ActionType::Txn,
             Self::CommitInfo(_) => ActionType::CommitInfo,
             Self::DomainMetadata(_) => ActionType::DomainMetadata,
+            Self::TGroup(_) => ActionType::TGroup,
         }
     }
 }


### PR DESCRIPTION
This PR adds `TGroup` as a possible log action.

### Files Changed
The following files have been modified:
* `kernel/model/mod.rs`: Action declaration
* `kernel/models/fields.rs`: Schema definition for the action
* `actions.rs`: Action definition

### `TGroup` Action
The `TGroup` action contains the following fields:
- `tgroup_uri`: URI of the T-group to which table is added.
- `timestamp`: Timestamp at which the log was added. When table is being added to a T-group, this lets us automatically assume failure after time *t*.
- `redirect_state`: Enum identifying the state of addition to T-group. Can take the following values:
  - `ReadOnly`: Readers can continue reading from the table as usual. Writers must block or retry. The log line is valid only up to time _t_ after the `timestamp` in the log.
  - `Redirect`: Readers and writers must use the T-group's logs.
  - `TimedOut`: Denotes that T-group creation failed. Readers and writers can use the table's logs. This is more of an informational line. (We can probably get rid of this later if we don't end up using it.)